### PR TITLE
Allow empty array default 2

### DIFF
--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -174,16 +174,22 @@ class Parser
       when Date; :date
       when Array
         if opts[:default].empty?
-          raise ArgumentError, "multiple argument type cannot be deduced from an empty array for '#{opts[:default][0].class.name}'"
-        end
-        case opts[:default][0]    # the first element determines the types
-        when Integer; :ints
-        when Numeric; :floats
-        when String; :strings
-        when IO; :ios
-        when Date; :dates
+          if opts[:type]
+            raise ArgumentError, "multiple argument type must be plural" unless MULTI_ARG_TYPES.include?(opts[:type])
+            nil
+          else
+            raise ArgumentError, "multiple argument type cannot be deduced from an empty array for '#{opts[:default][0].class.name}'"
+          end
         else
-          raise ArgumentError, "unsupported multiple argument type '#{opts[:default][0].class.name}'"
+          case opts[:default][0]    # the first element determines the types
+          when Integer; :ints
+          when Numeric; :floats
+          when String; :strings
+          when IO; :ios
+          when Date; :dates
+          else
+            raise ArgumentError, "unsupported multiple argument type '#{opts[:default][0].class.name}'"
+          end
         end
       when nil; nil
       else

--- a/test/test_trollop.rb
+++ b/test/test_trollop.rb
@@ -208,7 +208,7 @@ class Trollop < ::Test::Unit::TestCase
     assert_raise(ArgumentError) { @p.opt "badf", "desc", :type => :float, :default => [] }
     assert_raise(ArgumentError) { @p.opt "badd", "desc", :type => :date, :default => [] }
     assert_raise(ArgumentError) { @p.opt "bads", "desc", :type => :string, :default => [] }
-    opts = @p.parse("")
+    opts = @p.parse([])
     assert_equal(opts["argmi"], [])
     assert_equal(opts["argmf"], [])
     assert_equal(opts["argmd"], [])

--- a/test/test_trollop.rb
+++ b/test/test_trollop.rb
@@ -197,7 +197,22 @@ class Trollop < ::Test::Unit::TestCase
     opts = @p.parse(%w(--argd different_string))
     assert opts[:argd_given]
     assert_equal "different_string", opts[:argd]
+  end
 
+  def test_type_and_empty_array
+    assert_nothing_raised { @p.opt "argmi", "desc", :type => :ints, :default => [] }
+    assert_nothing_raised { @p.opt "argmf", "desc", :type => :floats, :default => [] }
+    assert_nothing_raised { @p.opt "argmd", "desc", :type => :dates, :default => [] }
+    assert_nothing_raised { @p.opt "argms", "desc", :type => :strings, :default => [] }
+    assert_raise(ArgumentError) { @p.opt "badi", "desc", :type => :int, :default => [] }
+    assert_raise(ArgumentError) { @p.opt "badf", "desc", :type => :float, :default => [] }
+    assert_raise(ArgumentError) { @p.opt "badd", "desc", :type => :date, :default => [] }
+    assert_raise(ArgumentError) { @p.opt "bads", "desc", :type => :string, :default => [] }
+    opts = @p.parse("")
+    assert_equal(opts["argmi"], [])
+    assert_equal(opts["argmf"], [])
+    assert_equal(opts["argmd"], [])
+    assert_equal(opts["argms"], [])
   end
 
   def test_long_detects_bad_names


### PR DESCRIPTION
Currently, it is simply forbidding to have an empty array as a default.  This is because trollop attempts to first derive the default, and then to compare that to the given type, and it is not possible to know the type of an empty array.

If the type is in fact given, however, there is no problem, so long as the type is a MULT_ARGS_TYPE.

(This is how I prefer my pull requests to look)