### PR TITLE
Followup to default parameters with no values.

### DIFF
--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -387,7 +387,7 @@ class Parser
       opts = @specs[sym]
       if params.empty? && opts[:type] != :flag
         raise CommandlineError, "option '#{arg}' needs a parameter" unless opts[:default]
-        params << [opts[:default]]
+        params << (opts[:default].kind_of?(Array) ? opts[:default].clone : [opts[:default]])
       end
 
       vals["#{sym}_given".intern] = true # mark argument as specified on the commandline

--- a/test/test_trollop.rb
+++ b/test/test_trollop.rb
@@ -195,6 +195,15 @@ class Trollop < ::MiniTest::Unit::TestCase
     assert_equal "different_string", opts[:argd]
   end
 
+  def test_flag_with_no_defaults_and_no_args_act_as_switches_array
+    opts = nil
+
+    @p.opt :argd, "desc", :type => :strings, :default => ["default_string"]
+
+    opts = @p.parse(%w(--argd))
+    assert_equal ["default_string"], opts[:argd]
+  end
+
   def test_type_and_empty_array
     @p.opt "argmi", "desc", :type => :ints, :default => []
     @p.opt "argmf", "desc", :type => :floats, :default => []


### PR DESCRIPTION
When a default is an array, and the user specifies a flag with no params
proceed as if all defaults were stated

Fixes #38 

@Fryguy Debating between this and just stating that #11 should be redacted