### PR TITLE
travis specific gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: ruby
 rvm:
   - "1.8.7"
   - "1.9.3"
-  - "2.0"
-  - "2.1"
   - "2.2"
   - ruby-head
-  - jruby-19mode # JRuby in 1.9 mode
   - jruby-head
+gemfile: Gemfile.travis

--- a/Gemfile.travis
+++ b/Gemfile.travis
@@ -1,4 +1,9 @@
 source 'https://rubygems.org'
 
+if RUBY_VERSION < "1.9"
+  gem 'rest-client', '< 1.7'
+  gem 'mime-types', '~> 1.16'
+end
+
 # Specify your gem's dependencies in trollop.gemspec
 gemspec


### PR DESCRIPTION
Have a gemfile for travis that works with 1.8

When Gemnasium parses `Gemfile` via regular expressions. So it is ignoring the `if` which is only used in ruby 1.8.

This PR introduces a travis specific Gemfile that lets travis install the proper gems for 1.8, but does not confuse Gemnasium.