### PR TITLE
Option class

### DIFF
--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -47,25 +47,6 @@ PARAM_RE = /^-(-|\.$|[^\d\.])/
 ## and consider calling it from within
 ## Trollop::with_standard_exception_handling.
 class Parser
-  ## The set of values that indicate a flag option when passed as the
-  ## +:type+ parameter of #opt.
-  FLAG_TYPES = [:flag, :bool, :boolean]
-
-  ## The set of values that indicate a single-parameter (normal) option when
-  ## passed as the +:type+ parameter of #opt.
-  ##
-  ## A value of +io+ corresponds to a readable IO resource, including
-  ## a filename, URI, or the strings 'stdin' or '-'.
-  SINGLE_ARG_TYPES = [:int, :integer, :string, :double, :float, :io, :date]
-
-  ## The set of values that indicate a multiple-parameter option (i.e., that
-  ## takes multiple space-separated values on the commandline) when passed as
-  ## the +:type+ parameter of #opt.
-  MULTI_ARG_TYPES = [:ints, :integers, :strings, :doubles, :floats, :ios, :dates]
-
-  ## The complete set of legal values for the +:type+ parameter of #opt.
-  TYPES = FLAG_TYPES + SINGLE_ARG_TYPES + MULTI_ARG_TYPES
-
   INVALID_SHORT_ARG_REGEX = /[\d-]/ #:nodoc:
 
   ## The values from the commandline that were not interpreted by #parse.
@@ -149,7 +130,7 @@ class Parser
     raise ArgumentError, "long option name #{o.long.inspect} is already taken; please specify a (different) :long" if @long[o.long]
     raise ArgumentError, "short option name #{o.short.inspect} is already taken; please specify a (different) :short" if @short[o.short]
     @long[o.long] = o.name
-    @short[o.short] = o.name if o.short && o.short != :none
+    @short[o.short] = o.name if o.short?
     @specs[o.name] = o
     @order << [:opt, o.name]
   end
@@ -275,10 +256,10 @@ class Parser
       num_params_taken = 0
 
       unless params.nil?
-        if SINGLE_ARG_TYPES.include?(@specs[sym][:type])
+        if @specs[sym].single_arg?
           given_args[sym][:params] << params[0, 1]  # take the first parameter
           num_params_taken = 1
-        elsif MULTI_ARG_TYPES.include?(@specs[sym][:type])
+        elsif @specs[sym].multi_arg?
           given_args[sym][:params] << params        # take all the parameters
           num_params_taken = params.size
         end
@@ -335,13 +316,13 @@ class Parser
         vals[sym] = params.map { |pg| pg.map { |p| parse_date_parameter p, arg } }
       end
 
-      if SINGLE_ARG_TYPES.include?(opts[:type])
+      if opts.single_arg?
         if opts[:multi]       # multiple options, each with a single parameter
           vals[sym] = vals[sym].map { |p| p[0] }
         else                  # single parameter
           vals[sym] = vals[sym][0][0]
         end
-      elsif MULTI_ARG_TYPES.include?(opts[:type]) && !opts[:multi]
+      elsif opts.multi_arg? && !opts[:multi]
         vals[sym] = vals[sym][0]  # single option, with multiple parameters
       end
       # else: multiple options, with multiple parameters
@@ -643,6 +624,25 @@ end
 
 ## The option for each flag
 class Option
+  ## The set of values that indicate a flag option when passed as the
+  ## +:type+ parameter of #opt.
+  FLAG_TYPES = [:flag, :bool, :boolean]
+
+  ## The set of values that indicate a single-parameter (normal) option when
+  ## passed as the +:type+ parameter of #opt.
+  ##
+  ## A value of +io+ corresponds to a readable IO resource, including
+  ## a filename, URI, or the strings 'stdin' or '-'.
+  SINGLE_ARG_TYPES = [:int, :integer, :string, :double, :float, :io, :date]
+
+  ## The set of values that indicate a multiple-parameter option (i.e., that
+  ## takes multiple space-separated values on the commandline) when passed as
+  ## the +:type+ parameter of #opt.
+  MULTI_ARG_TYPES = [:ints, :integers, :strings, :doubles, :floats, :ios, :dates]
+
+  ## The complete set of legal values for the +:type+ parameter of #opt.
+  TYPES = FLAG_TYPES + SINGLE_ARG_TYPES + MULTI_ARG_TYPES
+
   attr_accessor :name, :opts
 
   def initialize(name, desc="", opts={}, &b)
@@ -668,7 +668,7 @@ class Option
         end
       when nil             then nil
       else
-        raise ArgumentError, "unsupported argument type '#{opts[:type]}'" unless ::Trollop::Parser::TYPES.include?(opts[:type])
+        raise ArgumentError, "unsupported argument type '#{opts[:type]}'" unless TYPES.include?(opts[:type])
         opts[:type]
       end
 
@@ -694,7 +694,7 @@ class Option
       when Array
         if opts[:default].empty?
           if opts[:type]
-            raise ArgumentError, "multiple argument type must be plural" unless ::Trollop::Parser::MULTI_ARG_TYPES.include?(opts[:type])
+            raise ArgumentError, "multiple argument type must be plural" unless MULTI_ARG_TYPES.include?(opts[:type])
             nil
           else
             raise ArgumentError, "multiple argument type cannot be deduced from an empty array for '#{opts[:default][0].class.name}'"
@@ -753,7 +753,7 @@ class Option
   end
 
   def key?(name)
-    opts.has_key?(name)
+    opts.key?(name)
   end
 
   # mimic type
@@ -766,9 +766,19 @@ class Option
   end
 
   def type ;opts[:type] ; end
+  def single_arg?
+    SINGLE_ARG_TYPES.include?(type)
+  end
+
   def multi ; opts[:multi] ; end
+
+  def multi_arg?
+    MULTI_ARG_TYPES.include?(type)
+  end
+
   def default ; opts[:default] ; end
   def short ; opts[:short] ; end
+  def short? ; short && short != :none ; end
   def long ; opts[:long] ; end
   def callback ; opts[:callback] ; end
   def desc ; opts[:desc] ; end

--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -140,117 +140,18 @@ class Parser
   ## value, you must specify +:type+ as well.
 
   def opt(name, desc = "", opts = {}, &b)
-    raise ArgumentError, "you already have an argument named '#{name}'" if @specs.member? name
-
-    ## fill in :type
-    opts[:type] = # normalize
-      case opts[:type]
-      when :boolean, :bool then :flag
-      when :integer        then :int
-      when :integers       then :ints
-      when :double         then :float
-      when :doubles        then :floats
-      when Class
-        case opts[:type].name
-        when 'TrueClass',
-             'FalseClass'  then :flag
-        when 'String'      then :string
-        when 'Integer'     then :int
-        when 'Float'       then :float
-        when 'IO'          then :io
-        when 'Date'        then :date
-        else
-          raise ArgumentError, "unsupported argument type '#{opts[:type].class.name}'"
-        end
-      when nil             then nil
-      else
-        raise ArgumentError, "unsupported argument type '#{opts[:type]}'" unless TYPES.include?(opts[:type])
-        opts[:type]
-      end
-
-    ## for options with :multi => true, an array default doesn't imply
-    ## a multi-valued argument. for that you have to specify a :type
-    ## as well. (this is how we disambiguate an ambiguous situation;
-    ## see the docs for Parser#opt for details.)
-    disambiguated_default = if opts[:multi] && opts[:default].kind_of?(Array) && !opts[:type]
-      opts[:default].first
-    else
-      opts[:default]
-    end
-
-    type_from_default =
-      case disambiguated_default
-      when Integer     then :int
-      when Numeric     then :float
-      when TrueClass,
-           FalseClass  then :flag
-      when String      then :string
-      when IO          then :io
-      when Date        then :date
-      when Array
-        if opts[:default].empty?
-          if opts[:type]
-            raise ArgumentError, "multiple argument type must be plural" unless MULTI_ARG_TYPES.include?(opts[:type])
-            nil
-          else
-            raise ArgumentError, "multiple argument type cannot be deduced from an empty array for '#{opts[:default][0].class.name}'"
-          end
-        else
-          case opts[:default][0]    # the first element determines the types
-          when Integer then :ints
-          when Numeric then :floats
-          when String  then :strings
-          when IO      then :ios
-          when Date    then :dates
-          else
-            raise ArgumentError, "unsupported multiple argument type '#{opts[:default][0].class.name}'"
-          end
-        end
-      when nil         then nil
-      else
-        raise ArgumentError, "unsupported argument type '#{opts[:default].class.name}'"
-      end
-
-    raise ArgumentError, ":type specification and default type don't match (default type is #{type_from_default})" if opts[:type] && type_from_default && opts[:type] != type_from_default
-
-    opts[:type] = opts[:type] || type_from_default || :flag
-
-    ## fill in :long
-    opts[:long] = opts[:long] ? opts[:long].to_s : name.to_s.gsub("_", "-")
-    opts[:long] = case opts[:long]
-      when /^--([^-].*)$/ then $1
-      when /^[^-]/        then opts[:long]
-      else                     raise ArgumentError, "invalid long option name #{opts[:long].inspect}"
-    end
-    raise ArgumentError, "long option name #{opts[:long].inspect} is already taken; please specify a (different) :long" if @long[opts[:long]]
-
-    ## fill in :short
-    opts[:short] = opts[:short].to_s if opts[:short] && opts[:short] != :none
-    opts[:short] = case opts[:short]
-      when /^-(.)$/          then $1
-      when nil, :none, /^.$/ then opts[:short]
-      else                   raise ArgumentError, "invalid short option name '#{opts[:short].inspect}'"
-    end
-
-    if opts[:short]
-      raise ArgumentError, "short option name #{opts[:short].inspect} is already taken; please specify a (different) :short" if @short[opts[:short]]
-      raise ArgumentError, "a short option name can't be a number or a dash" if opts[:short] =~ INVALID_SHORT_ARG_REGEX
-    end
-
-    ## fill in :default for flags
-    opts[:default] = false if opts[:type] == :flag && opts[:default].nil?
-
-    ## autobox :default for :multi (multi-occurrence) arguments
-    opts[:default] = [opts[:default]] if opts[:default] && opts[:multi] && !opts[:default].kind_of?(Array)
-
-    ## fill in :multi
-    opts[:multi] ||= false
     opts[:callback] ||= b if block_given?
     opts[:desc] ||= desc
-    @long[opts[:long]] = name
-    @short[opts[:short]] = name if opts[:short] && opts[:short] != :none
-    @specs[name] = opts
-    @order << [:opt, name]
+
+    o = Option.create(name, desc, opts)
+
+    raise ArgumentError, "you already have an argument named '#{name}'" if @specs.member? o.name
+    raise ArgumentError, "long option name #{o.long.inspect} is already taken; please specify a (different) :long" if @long[o.long]
+    raise ArgumentError, "short option name #{o.short.inspect} is already taken; please specify a (different) :short" if @short[o.short]
+    @long[o.long] = o.name
+    @short[o.short] = o.name if o.short && o.short != :none
+    @specs[o.name] = o
+    @order << [:opt, o.name]
   end
 
   ## Sets the version string. If set, the user can request the version
@@ -737,6 +638,143 @@ private
       remove_method :cloaker_
       meth
     end
+  end
+end
+
+## The option for each flag
+class Option
+  attr_accessor :name, :opts
+
+  def initialize(name, desc="", opts={}, &b)
+    ## fill in :type
+    opts[:type] = # normalize
+      case opts[:type]
+      when :boolean, :bool then :flag
+      when :integer        then :int
+      when :integers       then :ints
+      when :double         then :float
+      when :doubles        then :floats
+      when Class
+        case opts[:type].name
+        when 'TrueClass',
+             'FalseClass'  then :flag
+        when 'String'      then :string
+        when 'Integer'     then :int
+        when 'Float'       then :float
+        when 'IO'          then :io
+        when 'Date'        then :date
+        else
+          raise ArgumentError, "unsupported argument type '#{opts[:type].class.name}'"
+        end
+      when nil             then nil
+      else
+        raise ArgumentError, "unsupported argument type '#{opts[:type]}'" unless ::Trollop::Parser::TYPES.include?(opts[:type])
+        opts[:type]
+      end
+
+    ## for options with :multi => true, an array default doesn't imply
+    ## a multi-valued argument. for that you have to specify a :type
+    ## as well. (this is how we disambiguate an ambiguous situation;
+    ## see the docs for Parser#opt for details.)
+    disambiguated_default = if opts[:multi] && opts[:default].kind_of?(Array) && !opts[:type]
+      opts[:default].first
+    else
+      opts[:default]
+    end
+
+    type_from_default =
+      case disambiguated_default
+      when Integer     then :int
+      when Numeric     then :float
+      when TrueClass,
+           FalseClass  then :flag
+      when String      then :string
+      when IO          then :io
+      when Date        then :date
+      when Array
+        if opts[:default].empty?
+          if opts[:type]
+            raise ArgumentError, "multiple argument type must be plural" unless ::Trollop::Parser::MULTI_ARG_TYPES.include?(opts[:type])
+            nil
+          else
+            raise ArgumentError, "multiple argument type cannot be deduced from an empty array for '#{opts[:default][0].class.name}'"
+          end
+        else
+          case opts[:default][0]    # the first element determines the types
+          when Integer then :ints
+          when Numeric then :floats
+          when String  then :strings
+          when IO      then :ios
+          when Date    then :dates
+          else
+            raise ArgumentError, "unsupported multiple argument type '#{opts[:default][0].class.name}'"
+          end
+        end
+      when nil         then nil
+      else
+        raise ArgumentError, "unsupported argument type '#{opts[:default].class.name}'"
+      end
+
+    raise ArgumentError, ":type specification and default type don't match (default type is #{type_from_default})" if opts[:type] && type_from_default && opts[:type] != type_from_default
+
+    opts[:type] = opts[:type] || type_from_default || :flag
+
+    ## fill in :long
+    opts[:long] = opts[:long] ? opts[:long].to_s : name.to_s.gsub("_", "-")
+    opts[:long] = case opts[:long]
+      when /^--([^-].*)$/ then $1
+      when /^[^-]/        then opts[:long]
+      else                     raise ArgumentError, "invalid long option name #{opts[:long].inspect}"
+    end
+
+    ## fill in :short
+    opts[:short] = opts[:short].to_s if opts[:short] && opts[:short] != :none
+    opts[:short] = case opts[:short]
+      when /^-(.)$/          then $1
+      when nil, :none, /^.$/ then opts[:short]
+      else                   raise ArgumentError, "invalid short option name '#{opts[:short].inspect}'"
+    end
+
+    if opts[:short]
+      raise ArgumentError, "a short option name can't be a number or a dash" if opts[:short] =~ ::Trollop::Parser::INVALID_SHORT_ARG_REGEX
+    end
+
+    ## fill in :default for flags
+    opts[:default] = false if opts[:type] == :flag && opts[:default].nil?
+
+    ## autobox :default for :multi (multi-occurrence) arguments
+    opts[:default] = [opts[:default]] if opts[:default] && opts[:multi] && !opts[:default].kind_of?(Array)
+
+    ## fill in :multi
+    opts[:multi] ||= false
+
+    self.name = name
+    self.opts = opts
+  end
+
+  def key?(name)
+    opts.has_key?(name)
+  end
+
+  # mimic type
+  def [](name)
+    opts[name]
+  end
+
+  def []=(name, value)
+    opts[name] = value
+  end
+
+  def type ;opts[:type] ; end
+  def multi ; opts[:multi] ; end
+  def default ; opts[:default] ; end
+  def short ; opts[:short] ; end
+  def long ; opts[:long] ; end
+  def callback ; opts[:callback] ; end
+  def desc ; opts[:desc] ; end
+
+  def self.create(name, desc="", opts={})
+    new(name, desc, opts)
   end
 end
 

--- a/test/trollop/parser_test.rb
+++ b/test/trollop/parser_test.rb
@@ -499,7 +499,7 @@ Options:
     assert_raises(ArgumentError) { @p.opt :arg, "desc", :short => "-1" }
     @p.opt :a1b, "desc"
     @p.opt :a2b, "desc"
-    assert @p.specs[:a2b][:short].to_i == 0
+    assert @p.specs[:a2b].short.to_i == 0
   end
 
   def test_short_options_can_be_weird
@@ -676,7 +676,7 @@ Options:
 
   def test_auto_generated_long_names_convert_underscores_to_hyphens
     @p.opt :hello_there
-    assert_equal "hello-there", @p.specs[:hello_there][:long]
+    assert_equal "hello-there", @p.specs[:hello_there].long
   end
 
   def test_arguments_passed_through_block


### PR DESCRIPTION
@Fryguy this is just the beginning

Want to move each parameter option into its own class.
In the longer term, most of the case statements will be converted to inheritance / ducktyping.

downside:

some constants in the documented public interface will go away (e.g.: `FLOAT_RE`, `MULTI_ARG_TYPES`). Not sure if semver says this is a major or minor update.
I really don't think anyone should be accessing those constants.

I'm debating many PRs. Or a single PR. (single PR is nice to get a feel for the final product)
