### PR TITLE
Hide verbose output

### DIFF
--- a/test/test_trollop.rb
+++ b/test/test_trollop.rb
@@ -1195,6 +1195,18 @@ Options:
         end
       end
     end
+
+    # ensure regular status is returned
+
+    assert_stdout do
+      begin
+        ::Trollop::options(%w(-h)) do
+          opt :potato
+        end
+      rescue SystemExit => e
+        assert_equal 0, e.status
+      end
+    end
   end
 
   def test_simple_interface_handles_version
@@ -1233,12 +1245,38 @@ Options:
     end
   end
 
+  def test_invalid_option_with_simple_interface
+    assert_stderr do
+      assert_raises(SystemExit) do
+        ::Trollop.options(%w(--potato))
+      end
+    end
+
+    assert_stderr do
+      begin
+        ::Trollop.options(%w(--potato))
+      rescue SystemExit => e
+        assert_equal -1, e.status
+      end
+    end
+  end
+
   def test_error_with_standard_exception_handling
     assert_stderr /Error: cl error/ do
       assert_raises(SystemExit) do
         ::Trollop.with_standard_exception_handling(@p) do
           raise ::Trollop::CommandlineError.new('cl error')
         end
+      end
+    end
+
+    assert_stderr do
+      begin
+        ::Trollop.with_standard_exception_handling(@p) do
+          raise ::Trollop::CommandlineError.new('cl error')
+        end
+      rescue SystemExit => e
+        assert_equal -1, e.status
       end
     end
   end

--- a/test/test_trollop.rb
+++ b/test/test_trollop.rb
@@ -1189,20 +1189,16 @@ Options:
   end
 
   def test_simple_interface_handles_help
-    ARGV.clear
-    ARGV.unshift "-h"
     assert_raises(SystemExit) do
-      ::Trollop::options do
+      ::Trollop::options(%w(-h)) do
         opt :potato
       end
     end
   end
 
   def test_simple_interface_handles_version
-    ARGV.clear
-    ARGV.unshift "-v"
     assert_raises(SystemExit) do
-      ::Trollop::options do
+      ::Trollop::options(%w(-v)) do
         version "1.2"
         opt :potato
       end
@@ -1210,9 +1206,7 @@ Options:
   end
 
   def test_simple_interface_handles_regular_usage
-    ARGV.clear
-    ARGV.unshift "--potato"
-    opts = ::Trollop::options do
+    opts = ::Trollop::options(%w(--potato)) do
       opt :potato
     end
     assert opts[:potato]
@@ -1220,9 +1214,7 @@ Options:
 
   def test_simple_interface_handles_die
     old_stderr, $stderr = $stderr, StringIO.new('w')
-    ARGV.clear
-    ARGV.unshift "--potato"
-    ::Trollop::options do
+    ::Trollop::options(%w(--potato)) do
       opt :potato
     end
     assert_raises(SystemExit) { ::Trollop::die :potato, "is invalid" }
@@ -1232,9 +1224,7 @@ Options:
 
   def test_simple_interface_handles_die_without_message
     old_stderr, $stderr = $stderr, StringIO.new('w')
-    ARGV.clear
-    ARGV.unshift "--potato"
-    opts = ::Trollop::options do
+    opts = ::Trollop::options(%w(--potato)) do
       opt :potato
     end
     assert_raises(SystemExit) { ::Trollop::die :potato }


### PR DESCRIPTION
too much trash in test output.

bunch of "Options: ..."

Also ensure that the system is exiting with an error status for errors and not for help.

/cc @Fryguy 