### PR TITLE
Splitup tests

### DIFF
--- a/Gemfile.travis
+++ b/Gemfile.travis
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
+# these are needed by coveralls
+# if this were in Gemfile, gemnasium thinks the mime-types is hardcoded
+# to an older version and complains. They are using regex's to parse ruby
 if RUBY_VERSION < "1.9"
   gem 'rest-client', '< 1.7'
   gem 'mime-types', '~> 1.16'

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ task :default => :test
 
 Rake::TestTask.new do |t|
   t.libs << 'test'
-  t.pattern = "test/test_*.rb"
+  t.pattern = "test/**/*_test.rb"
 end
 
 begin

--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -6,6 +6,8 @@
 require 'date'
 
 module Trollop
+  # note: this is duplicated in gemspec
+  # please change over there too
 VERSION = "2.1.2"
 
 ## Thrown by Parser in the event of a commandline error. Not needed if

--- a/test/support/assert_helpers.rb
+++ b/test/support/assert_helpers.rb
@@ -1,0 +1,25 @@
+module AssertHelpers
+  def assert_parses_correctly(parser, commandline, expected_opts,
+                              expected_leftovers)
+    opts = parser.parse commandline
+    assert_equal expected_opts, opts
+    assert_equal expected_leftovers, parser.leftovers
+  end
+
+  def assert_stderr(msg = nil)
+    old_stderr, $stderr = $stderr, StringIO.new('')
+    yield
+    assert_match msg, $stderr.string if msg
+  ensure
+    $stderr = old_stderr
+  end
+
+  def assert_stdout(msg = nil)
+    old_stdout, $stdout = $stdout, StringIO.new('')
+    yield
+    assert_match msg, $stdout.string if msg
+  ensure
+    $stdout = old_stdout
+  end
+end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,6 @@ end
 require 'minitest/autorun'
 
 Dir[File.expand_path('../support/**/*.rb', __FILE__)].each { |f| require f }
-::MiniTest::Unit::TestCase.send(:include, AssertHelpers)
+::MiniTest::Test.send(:include, AssertHelpers)
 
 require 'trollop'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,4 +15,7 @@ end
 
 require 'minitest/autorun'
 
+Dir[File.expand_path('../support/**/*.rb', __FILE__)].each { |f| require f }
+::MiniTest::Unit::TestCase.send(:include, AssertHelpers)
+
 require 'trollop'

--- a/test/test_trollop.rb
+++ b/test/test_trollop.rb
@@ -983,13 +983,6 @@ Options:
     assert_equal @q.leftovers, []
   end
 
-  def assert_parses_correctly(parser, commandline, expected_opts,
-                              expected_leftovers)
-    opts = parser.parse commandline
-    assert_equal expected_opts, opts
-    assert_equal expected_leftovers, parser.leftovers
-  end
-
   def test_unknown_subcommand
     @p.opt :global_flag, "Global flag", :short => "-g", :type => :flag
     @p.opt :global_param, "Global parameter", :short => "-p", :default => 5
@@ -1295,24 +1288,6 @@ Options:
       @p.opt :cb1, "with callback", :callback => lambda { |vals| raise "good" }
       @p.parse(%w(--cb1))
     end
-  end
-
-  private
-
-  def assert_stderr(msg = nil)
-    old_stderr, $stderr = $stderr, StringIO.new('')
-    yield
-    assert_match msg, $stderr.string if msg
-  ensure
-    $stderr = old_stderr
-  end
-
-  def assert_stdout(msg = nil)
-    old_stdout, $stdout = $stdout, StringIO.new('')
-    yield
-    assert_match msg, $stdout.string if msg
-  ensure
-    $stdout = old_stdout
   end
 end
 

--- a/test/trollop/parser_test.rb
+++ b/test/trollop/parser_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 module Trollop
 
-class ParserTest < ::MiniTest::Unit::TestCase
+class ParserTest < ::MiniTest::Test
   def setup
     @p = Parser.new
   end

--- a/test/trollop/parser_test.rb
+++ b/test/trollop/parser_test.rb
@@ -2,9 +2,8 @@ require 'stringio'
 require 'test_helper'
 
 module Trollop
-module Test
 
-class Trollop < ::MiniTest::Unit::TestCase
+class ParserTest < ::MiniTest::Unit::TestCase
   def setup
     @p = Parser.new
   end
@@ -1291,5 +1290,4 @@ Options:
   end
 end
 
-end
 end

--- a/trollop.gemspec
+++ b/trollop.gemspec
@@ -22,10 +22,8 @@ specify."
 
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "minitest", "~> 4.7.3"
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "minitest", "~> 5.4.3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "chronic"
   spec.add_development_dependency "coveralls"
-  spec.add_development_dependency "mime-types"
 end

--- a/trollop.gemspec
+++ b/trollop.gemspec
@@ -1,11 +1,10 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'trollop'
 
 Gem::Specification.new do |spec|
   spec.name          = "trollop"
-  spec.version       = Trollop::VERSION
+  spec.version       = "2.1.2"
   spec.authors       = ["William Morgan", "Keenan Brock"]
   spec.email         = "keenan@thebrocks.net"
   spec.summary       = "Trollop is a commandline option parser for Ruby that just gets out of your way."


### PR DESCRIPTION
I want more confidence in the tests (so I can refactor).

- move test files so we can split them out
- upgrade minitest
- don't `include "trollop"` in `Gemfile` that is producing a false 100% coverage