### PR TITLE
allow failures with ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ rvm:
   - ruby-head
   - jruby-head
 gemfile: Gemfile.travis
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true


### PR DESCRIPTION
Having some trouble with travis and ruby-head.
It is failing to build `unf_ext`. (Think this is a coveralls dependency?)

Marking ruby-head as ok to fail.

@Fryguy Thoughts