### PR TITLE
add ability to give errors custom exit codes

### DIFF
--- a/test/trollop_test.rb
+++ b/test/trollop_test.rb
@@ -51,6 +51,15 @@ class TrollopTest < MiniTest::Test
     end
   end
 
+  def test_die_custom_error_code
+    assert_stderr(/Error: issue with parsing/) do
+      assert_system_exit(5) do
+        Trollop.options []
+        Trollop.die "issue with parsing", nil, 5
+      end
+    end
+  end
+
   def test_educate_without_options_ever_run
     assert_raises(ArgumentError) { Trollop.educate }
   end
@@ -115,12 +124,34 @@ class TrollopTest < MiniTest::Test
     end
   end
 
+  def test_with_standard_exception_die_exception_custom_error
+    assert_stderr(/Error: cl error/) do
+      assert_system_exit(5) do
+        p = parser
+        Trollop.with_standard_exception_handling(p) do
+          raise ::Trollop::CommandlineError.new('cl error', 5)
+        end
+      end
+    end
+  end
+
   def test_with_standard_exception_die
     assert_stderr(/Error: cl error/) do
       assert_system_exit(-1) do
         p = parser
         Trollop.with_standard_exception_handling(p) do
           p.die 'cl error'
+        end
+      end
+    end
+  end
+
+  def test_with_standard_exception_die_custom_error
+    assert_stderr(/Error: cl error/) do
+      assert_system_exit(3) do
+        p = parser
+        Trollop.with_standard_exception_handling(p) do
+          p.die 'cl error', nil, 3
         end
       end
     end


### PR DESCRIPTION
Not thrilled about changing `CommandLineError`, but seemed the best option

Fixes #57 

/cc @Fryguy @jaredbeck