### PR TITLE
properly display usage

### DIFF
--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -262,7 +262,7 @@ class Parser
   ## first line in the help (educate) output and ending in two new
   ## lines.
   def usage(s = nil)
-    s ? @usage = s : @version
+    s ? @usage = s : @usage
   end
 
   ## Adds a synopsis (command summary description) right below the

--- a/test/trollop/command_line_error_test.rb
+++ b/test/trollop/command_line_error_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+module Trollop
+  class CommandlineErrorTest < ::MiniTest::Test
+    def test_class
+      assert_kind_of Exception, cle("message")
+    end
+
+    def test_message
+      assert "message", cle("message").message
+    end
+
+    def test_error_code_default
+      assert_nil cle("message").error_code
+    end
+
+    def test_error_code_custom
+      assert_equal(-3, cle("message", -3).error_code)
+    end
+
+    private
+
+    def cle(*args)
+      CommandlineError.new(*args)
+    end
+  end
+end

--- a/test/trollop/help_needed_test.rb
+++ b/test/trollop/help_needed_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+module Trollop
+  class HelpNeededTest < ::MiniTest::Test
+    def test_class
+      assert_kind_of Exception, hn("message")
+    end
+
+    def test_message
+      assert "message", hn("message").message
+    end
+
+    private
+
+    def hn(*args)
+      HelpNeeded.new(*args)
+    end
+  end
+end

--- a/test/trollop/parser_test.rb
+++ b/test/trollop/parser_test.rb
@@ -8,6 +8,29 @@ class ParserTest < ::MiniTest::Test
     @p = Parser.new
   end
 
+  def parser
+    @p ||= Parser.new
+  end
+
+  def test_version
+    assert_nil parser.version
+    assert_equal "trollop 5.2.3", parser.version("trollop 5.2.3")
+    assert_equal "trollop 5.2.3", parser.version
+  end
+
+  def test_usage
+    assert_nil parser.usage
+
+    assert_equal "usage string", parser.usage("usage string")
+    assert_equal "usage string", parser.usage
+  end
+
+  def test_synopsis
+    assert_nil parser.synopsis
+
+    assert_equal "synopsis string", parser.synopsis("synopsis string")
+    assert_equal "synopsis string", parser.synopsis
+  end
   def test_unknown_arguments
     assert_raises(CommandlineError) { @p.parse(%w(--arg)) }
     @p.opt "arg"

--- a/test/trollop/version_needed_test.rb
+++ b/test/trollop/version_needed_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+module Trollop
+  class VersionNeededTest < ::MiniTest::Test
+    def test_class
+      assert_kind_of Exception, vn("message")
+    end
+
+    def test_message
+      assert "message", vn("message").message
+    end
+
+    private
+
+    def vn(*args)
+      VersionNeeded.new(*args)
+    end
+  end
+end

--- a/test/trollop_test.rb
+++ b/test/trollop_test.rb
@@ -20,7 +20,7 @@ class TrollopTest < MiniTest::Test
   def test_options_die_default
     assert_stderr(/Error: unknown argument.*Try --help/m) do
       assert_system_exit(-1) do
-        opts = Trollop.options %w(-f) do
+        Trollop.options %w(-f) do
           opt :x
         end
       end


### PR DESCRIPTION
refactored `usage` incorrectly. put it back
Add specs around the getter/setters for educate