### PR TITLE
Test parser

### DIFF
--- a/test/trollop/parser_educate_test.rb
+++ b/test/trollop/parser_educate_test.rb
@@ -1,0 +1,175 @@
+require 'stringio'
+require 'test_helper'
+
+module Trollop
+  class ParserEduateTest < ::MiniTest::Test
+    def setup
+    end
+
+    def test_no_arguments_to_stdout
+      assert_stdout(/Options:/) do
+        parser.educate
+      end
+    end
+
+    def test_argument_to_stringio
+      assert_educates(/Options:/)
+    end
+
+    def test_no_headers
+      assert_educates(/^Options:/)
+    end
+
+    def test_usage
+      parser.usage("usage string")
+      assert_educates(/^Usage: \w* usage string\n\nOptions:/)
+    end
+
+    def test_usage_synopsis_version
+    end
+
+    # def test_banner
+    # def test_text
+
+      # width, legacy_width
+      # wrap
+      # wrap_lines
+
+############
+# convert these into multiple tests
+# pulled out of trollop_test for now
+  def test_help_has_default_banner
+    @p = Parser.new
+    sio = StringIO.new "w"
+    @p.parse []
+    @p.educate sio
+    help = sio.string.split "\n"
+    assert help[0] =~ /options/i
+    assert_equal 2, help.length # options, then -h
+
+    @p = Parser.new
+    @p.version "my version"
+    sio = StringIO.new "w"
+    @p.parse []
+    @p.educate sio
+    help = sio.string.split "\n"
+    assert help[0] =~ /my version/i
+    assert_equal 4, help.length # version, options, -h, -v
+
+    @p = Parser.new
+    @p.banner "my own banner"
+    sio = StringIO.new "w"
+    @p.parse []
+    @p.educate sio
+    help = sio.string.split "\n"
+    assert help[0] =~ /my own banner/i
+    assert_equal 2, help.length # banner, -h
+
+    @p = Parser.new
+    @p.text "my own text banner"
+    sio = StringIO.new "w"
+    @p.parse []
+    @p.educate sio
+    help = sio.string.split "\n"
+    assert help[0] =~ /my own text banner/i
+    assert_equal 2, help.length # banner, -h
+  end
+
+  def test_help_has_optional_usage
+    @p = Parser.new
+    @p.usage "OPTIONS FILES"
+    sio = StringIO.new "w"
+    @p.parse []
+    @p.educate sio
+    help = sio.string.split "\n"
+    assert help[0] =~ /OPTIONS FILES/i
+    assert_equal 4, help.length # line break, options, then -h
+  end
+
+  def test_help_has_optional_synopsis
+    @p = Parser.new
+    @p.synopsis "About this program"
+    sio = StringIO.new "w"
+    @p.parse []
+    @p.educate sio
+    help = sio.string.split "\n"
+    assert help[0] =~ /About this program/i
+    assert_equal 4, help.length # line break, options, then -h
+  end
+
+  def test_help_has_specific_order_for_usage_and_synopsis
+    @p = Parser.new
+    @p.usage "OPTIONS FILES"
+    @p.synopsis "About this program"
+    sio = StringIO.new "w"
+    @p.parse []
+    @p.educate sio
+    help = sio.string.split "\n"
+    assert help[0] =~ /OPTIONS FILES/i
+    assert help[1] =~ /About this program/i
+    assert_equal 5, help.length # line break, options, then -h
+  end
+
+  def test_help_preserves_positions
+    parser.opt :zzz, "zzz"
+    parser.opt :aaa, "aaa"
+    sio = StringIO.new "w"
+    parser.educate sio
+
+    help = sio.string.split "\n"
+    assert help[1] =~ /zzz/
+    assert help[2] =~ /aaa/
+  end
+
+  def test_help_includes_option_types
+    parser.opt :arg1, 'arg', :type => :int
+    parser.opt :arg2, 'arg', :type => :ints
+    parser.opt :arg3, 'arg', :type => :string
+    parser.opt :arg4, 'arg', :type => :strings
+    parser.opt :arg5, 'arg', :type => :float
+    parser.opt :arg6, 'arg', :type => :floats
+    parser.opt :arg7, 'arg', :type => :io
+    parser.opt :arg8, 'arg', :type => :ios
+    parser.opt :arg9, 'arg', :type => :date
+    parser.opt :arg10, 'arg', :type => :dates
+    sio = StringIO.new "w"
+    parser.educate sio
+
+    help = sio.string.split "\n"
+    assert help[1] =~ /<i>/
+    assert help[2] =~ /<i\+>/
+    assert help[3] =~ /<s>/
+    assert help[4] =~ /<s\+>/
+    assert help[5] =~ /<f>/
+    assert help[6] =~ /<f\+>/
+    assert help[7] =~ /<filename\/uri>/
+    assert help[8] =~ /<filename\/uri\+>/
+    assert help[9] =~ /<date>/
+    assert help[10] =~ /<date\+>/
+  end
+
+  def test_help_has_grammatical_default_text
+    parser.opt :arg1, 'description with period.', :default => 'hello'
+    parser.opt :arg2, 'description without period', :default => 'world'
+    sio = StringIO.new 'w'
+    parser.educate sio
+
+    help = sio.string.split "\n"
+    assert help[1] =~ /Default/
+    assert help[2] =~ /default/
+  end
+############
+
+    private
+
+    def parser
+      @p ||= Parser.new
+    end
+
+    def assert_educates(output)
+      str = StringIO.new
+      parser.educate str
+      assert_match output, str.string
+    end
+  end
+end

--- a/test/trollop/parser_opt_test.rb
+++ b/test/trollop/parser_opt_test.rb
@@ -1,0 +1,14 @@
+require 'stringio'
+require 'test_helper'
+
+module Trollop
+
+  class ParserOptTest < ::MiniTest::Test
+
+    private
+
+    def parser
+      @p ||= Parser.new
+    end
+  end
+end

--- a/test/trollop/parser_parse_test.rb
+++ b/test/trollop/parser_parse_test.rb
@@ -1,0 +1,79 @@
+require 'stringio'
+require 'test_helper'
+
+module Trollop
+  class ParserParseTest < ::MiniTest::Test
+
+  # TODO: parse
+    # resolve_default_short_options!
+    # parse_date_parameter
+    # parse_integer_parameter(param, arg)
+    # parse_float_parameter(param, arg)
+    # parse_io_parameter(param, arg)
+    # each_arg
+      # collect_argument_parameters
+
+  def test_help_needed
+    parser.opt "arg"
+    assert_raises(HelpNeeded) { parser.parse %w(-h) }
+    assert_raises(HelpNeeded) { parser.parse %w(--help) }
+  end
+
+  def test_help_overridden
+    parser.opt :arg1, "desc", :long => "help"
+    assert parser.parse(%w(-h))[:arg1]
+    assert parser.parse(%w(--help))[:arg1]
+  end
+
+  def test_help_with_other_args
+    parser.opt :arg1
+    assert_raises(HelpNeeded) { @p.parse %w(--arg1 --help) }
+  end
+
+  def test_help_with_arg_error
+    parser.opt :arg1, :type => String
+    assert_raises(HelpNeeded) { @p.parse %w(--arg1 --help) }
+  end
+
+  def test_version_needed_unset
+    parser.opt "arg"
+    assert_raises(CommandlineError) { parser.parse %w(-v) }
+  end
+
+  def test_version_needed
+    parser.version "trollop 5.2.3"
+    assert_raises(VersionNeeded) { parser.parse %w(-v) }
+    assert_raises(VersionNeeded) { parser.parse %w(--version) }
+  end
+
+  def test_version_overridden
+    parser.opt "version"
+    assert parser.parse(%w(-v))["version"]
+    assert parser.parse(%w(-v))[:version_given]
+  end
+
+  def test_version_only_appears_if_set
+    parser.opt "arg"
+    assert_raises(CommandlineError) { parser.parse %w(-v) }
+  end
+
+  def test_version_with_other_args
+    parser.opt :arg1
+    parser.version "1.1"
+    assert_raises(VersionNeeded) { parser.parse %w(--arg1 --version) }
+  end
+
+  def test_version_with_arg_error
+    parser.opt :arg1, :type => String
+    parser.version "1.1"
+    assert_raises(VersionNeeded) { parser.parse %w(--arg1 --version) }
+  end
+
+
+  private
+
+    def parser
+      @p ||= Parser.new
+    end
+  end
+end

--- a/test/trollop/parser_test.rb
+++ b/test/trollop/parser_test.rb
@@ -12,6 +12,9 @@ class ParserTest < ::MiniTest::Test
     @p ||= Parser.new
   end
 
+  # initialize
+  # cloaker
+
   def test_version
     assert_nil parser.version
     assert_equal "trollop 5.2.3", parser.version("trollop 5.2.3")
@@ -31,6 +34,16 @@ class ParserTest < ::MiniTest::Test
     assert_equal "synopsis string", parser.synopsis("synopsis string")
     assert_equal "synopsis string", parser.synopsis
   end
+
+  # def test_depends
+  # def test_conflicts
+  # def test_stop_on
+  # def test_stop_on_unknown
+
+  # die
+  # def test_die_educate_on_error
+
+
   def test_unknown_arguments
     assert_raises(CommandlineError) { @p.parse(%w(--arg)) }
     @p.opt "arg"
@@ -369,12 +382,6 @@ class ParserTest < ::MiniTest::Test
     assert_raises(CommandlineError) { @p.parse %w(--no-no-default-true) }
   end
 
-  def test_special_flags_work
-    @p.version "asdf fdas"
-    assert_raises(VersionNeeded) { @p.parse(%w(-v)) }
-    assert_raises(HelpNeeded) { @p.parse(%w(-h)) }
-  end
-
   def test_short_options_combine
     @p.opt :arg1, "desc", :short => "a"
     @p.opt :arg2, "desc", :short => "b"
@@ -397,13 +404,6 @@ class ParserTest < ::MiniTest::Test
 
     assert_raises(CommandlineError) { @p.parse %w(-cab 4) }
     assert_raises(CommandlineError) { @p.parse %w(-cba 4) }
-  end
-
-  def test_version_only_appears_if_set
-    @p.opt "arg"
-    assert_raises(CommandlineError) { @p.parse %w(-v) }
-    @p.version "trollop 1.2.3.4"
-    assert_raises(VersionNeeded) { @p.parse %w(-v) }
   end
 
   def test_doubledash_ends_option_processing
@@ -686,148 +686,6 @@ Options:
       boat = goat
     end
     assert_equal @goat, boat
-  end
-
-  def test_help_has_default_banner
-    @p = Parser.new
-    sio = StringIO.new "w"
-    @p.parse []
-    @p.educate sio
-    help = sio.string.split "\n"
-    assert help[0] =~ /options/i
-    assert_equal 2, help.length # options, then -h
-
-    @p = Parser.new
-    @p.version "my version"
-    sio = StringIO.new "w"
-    @p.parse []
-    @p.educate sio
-    help = sio.string.split "\n"
-    assert help[0] =~ /my version/i
-    assert_equal 4, help.length # version, options, -h, -v
-
-    @p = Parser.new
-    @p.banner "my own banner"
-    sio = StringIO.new "w"
-    @p.parse []
-    @p.educate sio
-    help = sio.string.split "\n"
-    assert help[0] =~ /my own banner/i
-    assert_equal 2, help.length # banner, -h
-
-    @p = Parser.new
-    @p.text "my own text banner"
-    sio = StringIO.new "w"
-    @p.parse []
-    @p.educate sio
-    help = sio.string.split "\n"
-    assert help[0] =~ /my own text banner/i
-    assert_equal 2, help.length # banner, -h
-  end
-
-  def test_help_has_optional_usage
-    @p = Parser.new
-    @p.usage "OPTIONS FILES"
-    sio = StringIO.new "w"
-    @p.parse []
-    @p.educate sio
-    help = sio.string.split "\n"
-    assert help[0] =~ /OPTIONS FILES/i
-    assert_equal 4, help.length # line break, options, then -h
-  end
-
-  def test_help_has_optional_synopsis
-    @p = Parser.new
-    @p.synopsis "About this program"
-    sio = StringIO.new "w"
-    @p.parse []
-    @p.educate sio
-    help = sio.string.split "\n"
-    assert help[0] =~ /About this program/i
-    assert_equal 4, help.length # line break, options, then -h
-  end
-
-  def test_help_has_specific_order_for_usage_and_synopsis
-    @p = Parser.new
-    @p.usage "OPTIONS FILES"
-    @p.synopsis "About this program"
-    sio = StringIO.new "w"
-    @p.parse []
-    @p.educate sio
-    help = sio.string.split "\n"
-    assert help[0] =~ /OPTIONS FILES/i
-    assert help[1] =~ /About this program/i
-    assert_equal 5, help.length # line break, options, then -h
-  end
-
-  def test_help_preserves_positions
-    @p.opt :zzz, "zzz"
-    @p.opt :aaa, "aaa"
-    sio = StringIO.new "w"
-    @p.educate sio
-
-    help = sio.string.split "\n"
-    assert help[1] =~ /zzz/
-    assert help[2] =~ /aaa/
-  end
-
-  def test_help_includes_option_types
-    @p.opt :arg1, 'arg', :type => :int
-    @p.opt :arg2, 'arg', :type => :ints
-    @p.opt :arg3, 'arg', :type => :string
-    @p.opt :arg4, 'arg', :type => :strings
-    @p.opt :arg5, 'arg', :type => :float
-    @p.opt :arg6, 'arg', :type => :floats
-    @p.opt :arg7, 'arg', :type => :io
-    @p.opt :arg8, 'arg', :type => :ios
-    @p.opt :arg9, 'arg', :type => :date
-    @p.opt :arg10, 'arg', :type => :dates
-    sio = StringIO.new "w"
-    @p.educate sio
-
-    help = sio.string.split "\n"
-    assert help[1] =~ /<i>/
-    assert help[2] =~ /<i\+>/
-    assert help[3] =~ /<s>/
-    assert help[4] =~ /<s\+>/
-    assert help[5] =~ /<f>/
-    assert help[6] =~ /<f\+>/
-    assert help[7] =~ /<filename\/uri>/
-    assert help[8] =~ /<filename\/uri\+>/
-    assert help[9] =~ /<date>/
-    assert help[10] =~ /<date\+>/
-  end
-
-  def test_help_has_grammatical_default_text
-    @p.opt :arg1, 'description with period.', :default => 'hello'
-    @p.opt :arg2, 'description without period', :default => 'world'
-    sio = StringIO.new 'w'
-    @p.educate sio
-
-    help = sio.string.split "\n"
-    assert help[1] =~ /Default/
-    assert help[2] =~ /default/
-  end
-
-  def test_version_and_help_short_args_can_be_overridden
-    @p.opt :verbose, "desc", :short => "-v"
-    @p.opt :hello, "desc", :short => "-h"
-    @p.version "version"
-
-    @p.parse(%w(-v))
-    assert_raises(VersionNeeded) { @p.parse(%w(--version)) }
-    @p.parse(%w(-h))
-    assert_raises(HelpNeeded) { @p.parse(%w(--help)) }
-  end
-
-  def test_version_and_help_long_args_can_be_overridden
-    @p.opt :asdf, "desc", :long => "help"
-    @p.opt :asdf2, "desc2", :long => "version"
-    @p.parse %w()
-    @p.parse %w(--help)
-    @p.parse %w(--version)
-    @p.parse %w(-h)
-    @p.parse %w(-v)
   end
 
   def test_version_and_help_override_errors

--- a/test/trollop_test.rb
+++ b/test/trollop_test.rb
@@ -30,7 +30,7 @@ class TrollopTest < MiniTest::Test
   def test_options_die_educate
     assert_stderr(/Error: unknown argument.*Options/m) do
       assert_system_exit(-1) do
-        opts = Trollop.options %w(-f) do
+        Trollop.options %w(-f) do
           opt :x
           educate_on_error
         end
@@ -176,19 +176,6 @@ class TrollopTest < MiniTest::Test
           p.parse(%w(-h))
         end
       end
-    end
-  end
-
-  # Looks like Parser#educate does not throw an exception
-  # Suggestion to just use p.die "message" and have it display the output
-  def test_with_standard_exception_educate
-    assert_stdout(/Options/) do
-      # assert_system_exit(0) do
-        p = parser
-        Trollop.with_standard_exception_handling(p) do
-          p.educate
-        end
-      # end
     end
   end
 end

--- a/test/trollop_test.rb
+++ b/test/trollop_test.rb
@@ -27,7 +27,7 @@ class TrollopTest < MiniTest::Test
     end
   end
 
-  def test_options_die_educate
+  def test_options_die_educate_on_error
     assert_stderr(/Error: unknown argument.*Options/m) do
       assert_system_exit(-1) do
         Trollop.options %w(-f) do
@@ -157,7 +157,7 @@ class TrollopTest < MiniTest::Test
     end
   end
 
-  def test_with_standard_exception_educate_exception
+  def test_with_standard_exception_help_needed
     assert_stdout(/Options/) do
       assert_system_exit(0) do
         p = parser
@@ -168,7 +168,7 @@ class TrollopTest < MiniTest::Test
     end
   end
 
-  def test_with_standard_exception_educate_flag
+  def test_with_standard_exception_help_needed_flag
     assert_stdout(/Options/) do
       assert_system_exit(0) do
         p = parser


### PR DESCRIPTION
Pull out the parser tests from the main trollop test suite

misc:

- moved renamed test names: educate/help 