### PR TITLE
Trollop.die now supports message, exit_code

### DIFF
--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -578,6 +578,7 @@ class Parser
 
   ## The per-parser version of Trollop::die (see that for documentation).
   def die(arg, msg = nil, error_code = nil)
+    msg, error_code = nil, msg if msg.kind_of?(Fixnum)
     if msg
       $stderr.puts "Error: argument --#{@specs[arg][:long]} #{msg}."
     else
@@ -828,6 +829,10 @@ end
 ##   end
 ##
 ##   Trollop::die "need at least one filename" if ARGV.empty?
+##
+## An exit code can be provide if needed
+##
+##   Trollop::die "need at least one filename", -2 if ARGV.empty?
 def die(arg, msg = nil, error_code = nil)
   if @last_parser
     @last_parser.die arg, msg, error_code

--- a/test/trollop_test.rb
+++ b/test/trollop_test.rb
@@ -60,6 +60,15 @@ class TrollopTest < MiniTest::Test
     end
   end
 
+  def test_die_custom_error_code_two_args
+    assert_stderr(/Error: issue with parsing/) do
+      assert_system_exit(5) do
+        Trollop.options []
+        Trollop.die "issue with parsing", 5
+      end
+    end
+  end
+
   def test_educate_without_options_ever_run
     assert_raises(ArgumentError) { Trollop.educate }
   end


### PR DESCRIPTION
Allow die to support 2 or 3 parameters

Follow up to #57 and #63 

@jaredbeck Does this work per our discussion?
