### PR TITLE
Add 1.9.2/2.0/2.1 to travis test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: ruby
 rvm:
   - "1.8.7"
+  - "1.9.2"
   - "1.9.3"
+  - "2.0"
+  - "2.1"
   - "2.2"
   - ruby-head
   - jruby-head


### PR DESCRIPTION
It's not clear if there was a reason to exclude these rubies... either way, I thought it was worth a try to see if we wanted to add them to the matrix.

I assume since we support 1.8.7 in travis, we probably should be testing 1.9.2.