### PR TITLE
Refer to the MIT license consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ Copyright &copy; 2008-2014 [William Morgan](http://masanjin.net/).
 
 Copyright &copy; 2014 Red Hat, Inc.
 
-Trollop is released under the [MIT License][http://www.opensource.org/licenses/MIT].
+Trollop is released under the [MIT License](http://www.opensource.org/licenses/MIT).

--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -1,7 +1,7 @@
 # lib/trollop.rb -- trollop command-line processing library
 # Copyright (c) 2008-2014 William Morgan.
 # Copyright (c) 2014 Red Hat, Inc.
-# trollop is licensed under the same terms as Ruby.
+# trollop is licensed under the MIT license.
 
 require 'date'
 


### PR DESCRIPTION
Similar to issue #47, there was still a reference to the Ruby license in the header of the lib/trollop.rb file which is amended here. In addition to this, the Markdown linking to the MIT license in the README.md file was broken; this is also fixed here, but isolated to its own commit.

Thank you!