### PR TITLE
Don't display default when it is blank

### DIFF
--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -528,7 +528,7 @@ class Parser
           spec[:default].to_s
         end
 
-        if spec[:default]
+        if spec[:default] && spec[:default] != ""
           if spec[:desc] =~ /\.$/
             " (Default: #{default_s})"
           else


### PR DESCRIPTION
on the command line don't add `(default: )` when the `default` is the
blank string ( `""`)
