### PR TITLE
remove coveralls to reduce dependencies

### DIFF
--- a/trollop.gemspec
+++ b/trollop.gemspec
@@ -25,5 +25,4 @@ specify."
   spec.add_development_dependency "minitest", "~> 5.4.3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "chronic"
-  spec.add_development_dependency "coveralls"
 end


### PR DESCRIPTION
coveralls is just requiring too many gems (3 vs many):

```diff
 chronic (0.10.2)
>  coveralls (0.7.11)
>    multi_json (~> 1.10)
>    rest-client (>= 1.6.8, < 2)
>    simplecov (~> 0.9.1)
>    term-ansicolor (~> 1.3)
>    thor (~> 0.19.1)
>  docile (1.1.5)
>  mime-types (2.4.3)
 minitest (5.4.3)
>  multi_json (1.10.1)
>  netrc (0.10.3)
 rake (10.4.2)
>  rest-client (1.7.3)
>    mime-types (>= 1.16, < 3.0)
>    netrc (~> 0.7)
>  simplecov (0.9.2)
>    docile (~> 1.1.0)
>    multi_json (~> 1.0)
>    simplecov-html (~> 0.9.0)
>  simplecov-html (0.9.0)
>  term-ansicolor (1.3.0)
>    tins (~> 1.0)
>  thor (0.19.1)
>  tins (1.3.4)
```