### PR TITLE
Tidy 215

### DIFF
--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -528,7 +528,7 @@ class Parser
           spec[:default].to_s
         end
 
-        if spec[:default]
+        if spec[:default] && spec[:default] != ""
           if spec[:desc] =~ /\.$/
             " (Default: #{default_s})"
           else

--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -92,7 +92,9 @@ class Parser
     @stop_words = []
     @stop_on_unknown = false
     @educate_on_error = false
-
+    @synopsis = nil
+    @usage = nil
+    
     # instance_eval(&b) if b # can't take arguments
     cloaker(&b).bind(self).call(*a) if b
   end

--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -518,7 +518,6 @@ class Parser
       end
 
       spec = @specs[opt]
-      next if spec[:hidden]
       stream.printf "  %-#{leftcol_width}s    ", left[opt]
       desc = spec[:desc] + begin
         default_s = case spec[:default]
@@ -531,7 +530,7 @@ class Parser
           spec[:default].to_s
         end
 
-        if spec[:default] && spec[:default] != ""
+        if spec[:default]
           if spec[:desc] =~ /\.$/
             " (Default: #{default_s})"
           else

--- a/test/trollop/parser_test.rb
+++ b/test/trollop/parser_test.rb
@@ -118,7 +118,7 @@ class ParserTest < ::MiniTest::Test
     opts = @p.parse(%w(--argsi=4))
     assert_equal 4, opts["argsi"]
     opts = @p.parse(%w(--argsi=-4))
-    assert_equal -4, opts["argsi"]
+    assert_equal( -4, opts["argsi"])
 
     assert_raises(CommandlineError) { @p.parse(%w(--argsi 4.2)) }
     assert_raises(CommandlineError) { @p.parse(%w(--argsi hello)) }
@@ -1056,7 +1056,7 @@ Options:
   end
 
   def test_simple_interface_handles_help
-    assert_stdout /Options:/ do
+    assert_stdout(/Options:/) do
       assert_raises(SystemExit) do
         ::Trollop::options(%w(-h)) do
           opt :potato
@@ -1078,7 +1078,7 @@ Options:
   end
 
   def test_simple_interface_handles_version
-    assert_stdout /1.2/ do
+    assert_stdout(/1.2/) do
       assert_raises(SystemExit) do
         ::Trollop::options(%w(-v)) do
           version "1.2"
@@ -1105,8 +1105,8 @@ Options:
   end
 
   def test_simple_interface_handles_die_without_message
-    assert_stderr /Error:/ do
-      opts = ::Trollop::options(%w(--potato)) do
+    assert_stderr(/Error:/) do
+      ::Trollop::options(%w(--potato)) do
         opt :potato
       end
       assert_raises(SystemExit) { ::Trollop::die :potato }
@@ -1124,7 +1124,7 @@ Options:
       begin
         ::Trollop.options(%w(--potato))
       rescue SystemExit => e
-        assert_equal -1, e.status
+        assert_equal(-1, e.status)
       end
     end
   end


### PR DESCRIPTION
Tidying up code and tests for ruby 2.1.5 when warnings are enabled.  Setting default `nil` values for `@usage` and `@synopsis`.  Also runs clean on ruby 2.3.0