### PR TITLE
better unix support for multi line comments

### DIFF
--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -546,7 +546,8 @@ class Parser
     @width ||= if $stdout.tty?
       begin
         require 'io/console'
-        IO.console.winsize.last
+        w = IO.console.winsize.last
+        w.to_i > 0 ? w : 80
       rescue LoadError, NoMethodError, Errno::ENOTTY, Errno::EBADF, Errno::EINVAL
         legacy_width
       end


### PR DESCRIPTION
travis returns a 0 for width.
This is causing odd wrapping issues and failing tests.

Now, we're defaulting to 80