### PR TITLE
Refactoring options, adding Option subclasses.

### DIFF
--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -676,27 +676,27 @@ class Option
 
     raise ArgumentError, ":type specification and default type don't match (default type is #{opttype_from_default.class})" if opttype && opttype_from_default && (opttype.class != opttype_from_default.class)
 
-    @optinst = (opttype || opttype_from_default || Trollop::BooleanOption.new)
+    opt_inst = (opttype || opttype_from_default || Trollop::BooleanOption.new)
 
     ## fill in :long
-    @optinst.long = handle_long_opt(opts[:long], name)
+    opt_inst.long = handle_long_opt(opts[:long], name)
 
     ## fill in :short
-    @optinst.short = handle_short_opt(opts[:short])
+    opt_inst.short = handle_short_opt(opts[:short])
     
     ## fill in :multi
     multi_given = opts[:multi] || false
-    @optinst.multi_given = multi_given
+    opt_inst.multi_given = multi_given
 
     ## fill in :default for flags
-    defvalue = opts[:default] || @optinst.default 
+    defvalue = opts[:default] || opt_inst.default 
 
     ## autobox :default for :multi (multi-occurrence) arguments
     defvalue = [defvalue] if defvalue && multi_given && !defvalue.kind_of?(Array)
-    @optinst.default = defvalue
-    @optinst.name = name
-    @optinst.opts = opts
-    @optinst
+    opt_inst.default = defvalue
+    opt_inst.name = name
+    opt_inst.opts = opts
+    opt_inst
   end
 
   private

--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -601,7 +601,7 @@ class Option
   ## Indicates a flag option, which is an option without an argument
   def flag? ; false ; end
   def single_arg?
-    !self.multi_arg? and !self.flag?
+    !self.multi_arg? && !self.flag?
   end
 
   def multi ; @multi_given ; end
@@ -634,25 +634,17 @@ class Option
   ## Format the educate-line description including the default-value(s)
   def description_with_default
     return desc unless default
-    defstring = begin
-                  default_s = case default
-                              when $stdout   then "<stdout>"
-                              when $stdin    then "<stdin>"
-                              when $stderr   then "<stderr>"
-                              when Array
-                                default.join(", ")
-                              else
-                                default.to_s
-                              end
-                  
-                  if desc =~ /\.$/
-                    " (Default: #{default_s})"
-                  else
-                    " (default: #{default_s})"
-                  end
+    default_s = case default
+                when $stdout   then '<stdout>'
+                when $stdin    then '<stdin>'
+                when $stderr   then '<stderr>'
+                when Array
+                  default.join(', ')
+                else
+                  default.to_s
                 end
-    return desc + defstring
-    
+    defword = desc.end_with?('.') ? 'Default' : 'default'
+    return "#{desc} (#{defword}: #{default_s})"
   end
 
   ## Provide a way to register symbol aliases to the Parser

--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -359,7 +359,8 @@ class Parser
     width # hack: calculate it now; otherwise we have to be careful not to
           # call this unless the cursor's at the beginning of a line.
 
-    left = @specs.map { |name, spec| [name, spec.educate] }.to_h
+    left = {}
+    @specs.each { |name, spec| left[name] = spec.educate }
     
     leftcol_width = left.values.map(&:length).max || 0
     rightcol_start = leftcol_width + 6 # spaces


### PR DESCRIPTION
This is a follow-on to @kbrock 's PR #93 

Rebased to manageiq/trollop/master and applied as minimal a change set as I could to implement the subclassing.  I thought I had rebased this properly before, but was quite mistaken.  

The "registry" still exists as a fixed hash (and currently without any user accessible functions) so that it can dispatch to the proper subclass.

The outward facing API changes were as minimal as possible.  I dont have a solution to the flag issue yet, perhaps we could just check `opt.is_a? BooleanOption`

